### PR TITLE
hacky media queries so the drupal admin doesn't hide our page.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -53,6 +53,82 @@ a.advanced-search-link {
 	font-size: 13px;
 }
 
+/*
+ **************
+ * Drupal Admin Overrides
+ **************
+*/
+
+/* This is ugly, but for whatever reason they set a height for this element... */
+div#toolbar div.toolbar-shortcuts ul {
+	height: auto;
+}
+
+/* The padding for the toolbar-drawer is set to !important, so the JS can't update it properly...*/
+/* Superhacky media queries! */
+body.toolbar-drawer {
+	padding-top: 283px !important;
+}
+
+@media (min-width: 266px) {
+	body.toolbar-drawer {
+		padding-top: 263px !important;
+	}
+}
+
+@media (min-width: 295px) {
+	body.toolbar-drawer {
+		padding-top: 243px !important;
+	}
+}
+
+@media (min-width: 297px) {
+	body.toolbar-drawer {
+		padding-top: 223px !important;
+	}
+}
+
+@media (min-width: 306px) {
+	body.toolbar-drawer {
+		padding-top: 199px !important;
+	}
+}
+
+@media (min-width: 356px) {
+	body.toolbar-drawer {
+		padding-top: 179px !important;
+	}
+}
+
+@media (min-width: 441px) {
+	body.toolbar-drawer {
+		padding-top: 159px !important;
+	}
+}
+
+@media (min-width: 451px) {
+	body.toolbar-drawer {
+		padding-top: 135px !important;
+	}
+}
+
+@media (min-width: 543px) {
+	body.toolbar-drawer {
+		padding-top: 104px !important;
+	}
+}
+
+@media (min-width: 786px) {
+	body.toolbar-drawer {
+		padding-top: 84px !important;
+	}
+}
+
+@media (min-width: 1006px) {
+	body.toolbar-drawer {
+		padding-top: 64px !important;
+	}
+}
 
 /*
  **************

--- a/css/style.css
+++ b/css/style.css
@@ -109,7 +109,7 @@ body.toolbar-drawer {
 
 @media (min-width: 451px) {
 	body.toolbar-drawer {
-		padding-top: 135px !important;
+		padding-top: 132px !important;
 	}
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -28,7 +28,6 @@ a.advanced-search-link {
 	font-size: 120%;
 }
 
-
 /*
  **************
  * Bootstrap overrides
@@ -137,6 +136,12 @@ body.toolbar-drawer {
  **************
 */
 
+@media (max-width: 767px) {
+	ul.secondary {
+		float:	none;
+	}
+}
+
 @media (min-width: 768px) {
 	.navbar-nav {
 		float: right;
@@ -180,6 +185,7 @@ body.toolbar-drawer {
 	background: #f6ac00;
 	color: #1c5793;
 }
+
 
 /*
  **************

--- a/css/style.css
+++ b/css/style.css
@@ -137,8 +137,22 @@ body.toolbar-drawer {
 */
 
 @media (max-width: 767px) {
+	.navbar-default .navbar-collapse {
+		background: #fff;
+		padding: 7.5px 15px;
+		border: 1px solid #000;
+	}
+
+	.navbar-default .nav li > a {
+		display: block;
+	}
+
 	ul.secondary {
 		float:	none;
+	}
+
+	.navbar-nav {
+		margin: 0;
 	}
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -12,6 +12,7 @@ body {
 	font-size: 150%;
 	color: #555555;
 	background-color: #fdfdfd;
+	min-width: 465px;
 }
 
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {

--- a/template.php
+++ b/template.php
@@ -66,7 +66,16 @@ function rula_preprocess_page(&$variables) {
     		else {
     $variables['navbar_classes_array'][] = 'navbar-default';
   }
-  }
+
+  // $viewport = array(
+  //   '#tag' => 'meta',
+  //   '#attributes' => array(
+  //     'name' => 'viewport',
+  //     'content' => 'width=465, initial-scale=1.0'
+  //   )
+  // );
+  // drupal_add_html_head($viewport, 'viewport');
+}
 
 /**
  * Implements hook_process_page().


### PR DESCRIPTION
For whatever reason, bootstrap/spacelab-bootstrap adds an !important flag to `body.toolbar-drawer` padding. This causes the Drupal admin to hide parts of our page on smaller resolutions because the JavaScript that adds the padding normally cannot override the !important flag.