### PR TITLE
Styles for browse pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -465,9 +465,8 @@ div#islandora-solr-result-count {
 */
 
 .breadcrumb {
-	width: 100%;
 	padding: 0;
-	background: transparent;
+	background: none;
 	margin-bottom: 12px;
 	font-size: 13px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -546,12 +546,14 @@ span.islandora-basic-collection-display-switch {
 }
 
 .islandora-basic-collection-list-item dl dt {
-	margin-right: 20px;
+	margin-right: 12px;
+	padding: 0;
 	width: 155px;
 }
 
 .islandora-basic-collection-list-item dl dd {
 	margin: 0;
+	padding: 0;
 }
 
 .islandora-basic-collection-list-item dt img {
@@ -559,6 +561,14 @@ span.islandora-basic-collection-display-switch {
  	border-radius: 0;
 }
  
+.islandora-basic-collection-list-item .dc-title {
+	font-size: 1.15em;
+}
+
+.islandora-basic-collection-list-item .dc-description {
+	margin-top: 0.5em;
+}
+
 .islandora-pdf-content-wrapper {
 	margin-left: -15px;
 	margin-right: -15px;

--- a/css/style.css
+++ b/css/style.css
@@ -546,7 +546,7 @@ span.islandora-basic-collection-display-switch {
 }
 
 .islandora-basic-collection-list-item dl dt {
-	margin-right: 12px;
+	margin-right: 10px;
 	padding: 0;
 	width: 155px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -516,13 +516,28 @@ div.islandora-pdf-metadata {
 	clear: none;
 }
 
+/*
+ **************
+ * Islandora browse pages
+ **************
+*/
+
+/* hide the gridview/listview button */
 span.islandora-basic-collection-display-switch {
 	display: none;
 }
 
-.islandora-basic-collection-list-item {
-	padding-bottom: 1em;
+.islandora-basic-collection .pagination {
 	margin: 0;
+}
+
+.islandora-basic-collection-list-item {
+	padding-top: 1em;
+	margin: 0;
+}
+
+.islandora-basic-collection-list-item:last-child {
+	border: 0;
 }
 
 .islandora-basic-collection-object dt img {

--- a/css/style.css
+++ b/css/style.css
@@ -532,17 +532,31 @@ span.islandora-basic-collection-display-switch {
 }
 
 .islandora-basic-collection-list-item {
-	padding-top: 1em;
 	margin: 0;
+	padding-top: 1em;
+	padding-bottom: 1em;
 }
 
 .islandora-basic-collection-list-item:last-child {
 	border: 0;
 }
 
+.islandora-basic-collection-object dl {
+	margin-bottom: 0;
+}
+
+.islandora-basic-collection-list-item dl dt {
+	margin-right: 20px;
+	width: 155px;
+}
+
+.islandora-basic-collection-list-item dl dd {
+	margin: 0;
+}
+
 .islandora-basic-collection-object dt img {
- 	border-radius: 0;
 	border: 1px solid silver;
+ 	border-radius: 0;
 }
  
 .islandora-pdf-content-wrapper {
@@ -552,8 +566,8 @@ span.islandora-basic-collection-display-switch {
 
 /* Islandora Download Link Style */
 .islandora_download_link a {
-	display: block;
 	border-radius: 0;
+	display: block;
 }
 
 /* Islandora Metadata */

--- a/css/style.css
+++ b/css/style.css
@@ -541,7 +541,7 @@ span.islandora-basic-collection-display-switch {
 	border: 0;
 }
 
-.islandora-basic-collection-object dl {
+.islandora-basic-collection-list-item dl {
 	margin-bottom: 0;
 }
 
@@ -554,7 +554,7 @@ span.islandora-basic-collection-display-switch {
 	margin: 0;
 }
 
-.islandora-basic-collection-object dt img {
+.islandora-basic-collection-list-item dt img {
 	border: 1px solid silver;
  	border-radius: 0;
 }


### PR DESCRIPTION
- makes the image thumb larger (150px)
- bump up the font size for title
- remove extra padding between elements
- wrap the description to use up all of the space in it's container
- make the dividing line situation a bit prettier

**BEFORE**
![before](https://cloud.githubusercontent.com/assets/2092558/13997814/3e872564-f10a-11e5-884e-f965333ced93.png)

**AFTER**
![browse](https://cloud.githubusercontent.com/assets/2092558/13997736/e5391792-f109-11e5-971a-46252bda76be.png)