### PR TITLE
Fix the "Download PDF" button on object pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -583,9 +583,22 @@ span.islandora-basic-collection-display-switch {
 }
 
 /* Islandora Download Link Style */
-.islandora_download_link a {
+.islandora_download_link a.islandora-pdf-link {
+	background: #1c5793;
 	border-radius: 0;
+	color: #fcfcfc;
 	display: block;
+	font-weight: 700;
+	margin: 0;
+	text-align: center;
+	text-transform: uppercase;
+	padding: 15px;
+	transition: background ease-in 0.2s;
+}
+
+.islandora_download_link a.islandora-pdf-link:hover {
+	text-decoration: none;
+	background: #3399f3;
 }
 
 /* Islandora Metadata */


### PR DESCRIPTION
Make the "Download PDF" link look like a button. Colour change eases in on mouseover.

**Mouse away**
![no-hover](https://cloud.githubusercontent.com/assets/2092558/14294145/9422978c-fb3d-11e5-82d4-354a1ae80148.png)

**Mouse over**
![hover](https://cloud.githubusercontent.com/assets/2092558/14294148/953f1122-fb3d-11e5-92c0-2cd0460f249c.png)
